### PR TITLE
Initialize AI app scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# test-codex
+# AI App Scaffold
+
+This project provides a minimal Next.js setup using the Vercel AI SDK and shadcn components. Chat requests sent to `/api/chat` are handled using the Agents SDK.
+
+## Getting Started
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start the development server
+   ```bash
+   npm run dev
+   ```
+
+The main UI can be found on the index page and uses shadcn UI components for a simple chat interface.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,19 @@
+import { openai } from '@ai-sdk/openai';
+import { StreamingTextResponse, streamText } from 'ai';
+import { createAgent } from 'agents';
+
+export const runtime = 'edge';
+
+const agent = createAgent({
+  system: 'You are a helpful AI assistant.'
+});
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const result = await streamText({
+    model: openai('gpt-3.5-turbo'),
+    messages,
+    agent
+  });
+  return new StreamingTextResponse(result.toAIStream());
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import Chat from '../components/Chat';
+
+export default function HomePage() {
+  return <Chat />;
+}

--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useChat } from 'ai/react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useEffect, useRef } from 'react';
+
+export default function Chat() {
+  const { messages, input, handleInputChange, handleSubmit } = useChat({
+    api: '/api/chat'
+  });
+
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  return (
+    <div className="flex flex-col gap-4 max-w-xl mx-auto p-4">
+      <div className="flex flex-col gap-2 max-h-80 overflow-auto">
+        {messages.map(m => (
+          <div key={m.id} className="whitespace-pre-wrap">
+            <strong>{m.role}:</strong> {m.content}
+          </div>
+        ))}
+        <div ref={endRef} />
+      </div>
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <Input value={input} onChange={handleInputChange} placeholder="Say something" />
+        <Button type="submit">Send</Button>
+      </form>
+    </div>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,10 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export function Button({ className = '', ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={`px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 ${className}`}
+      {...props}
+    />
+  );
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,10 @@
+import { InputHTMLAttributes } from 'react';
+
+export function Input({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className={`border rounded px-2 py-1 flex-1 ${className}`}
+      {...props}
+    />
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ai-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "ai": "latest",
+    "agents": "latest",
+    "shadcn-ui": "latest"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up Next.js app with TypeScript config
- add Vercel AI SDK chat UI using shadcn components
- handle `/api/chat` with Agents SDK
- document setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6854913c196c832a8d62cb9fbf5d3c61