### PR TITLE
Fix missing OpenAI dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-dom": "latest",
     "ai": "latest",
     "agents": "latest",
+    "@ai-sdk/openai": "latest",
     "shadcn-ui": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add missing `@ai-sdk/openai` dependency

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_685493addf3c832a81a2f54c75daebf6