### PR TITLE
Add streaming test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ This project provides a minimal Next.js setup using the Vercel AI SDK and shadcn
    ```
 
 The main UI can be found on the index page and uses shadcn UI components for a simple chat interface.
+
+## Testing the chat endpoint
+
+After starting the dev server you can verify the `/api/chat` endpoint using the
+`scripts/test-chat.ts` script:
+
+```bash
+npx ts-node scripts/test-chat.ts
+```
+
+This script sends a sample message and streams the reply to standard output.

--- a/scripts/test-chat.ts
+++ b/scripts/test-chat.ts
@@ -1,0 +1,25 @@
+import { Readable } from 'node:stream';
+
+async function main() {
+  const response = await fetch('http://localhost:3000/api/chat', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] })
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  const reader = (response.body as unknown as Readable)[Symbol.asyncIterator]();
+  for await (const chunk of reader) {
+    process.stdout.write(chunk);
+  }
+}
+
+main().catch(err => {
+  console.error('Error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a simple `scripts/test-chat.ts` script for exercising the chat endpoint
- update README with instructions for the test script

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685497524588832a923579ade287ffc6