### PR TITLE
Refactor to OpenAI Agents SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI App Scaffold
 
-This project provides a minimal Next.js setup using the Vercel AI SDK and shadcn components. Chat requests sent to `/api/chat` are handled using the Agents SDK.
+This project provides a minimal Next.js setup using the OpenAI Agents SDK together with shadcn components. Chat requests sent to `/api/chat` are handled using the Agents SDK.
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "start": "next start"
   },
   "dependencies": {
+    "@ai-sdk/openai": "latest",
+    "@openai/agents": "^0.0.9",
+    "agents": "latest",
+    "ai": "latest",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "ai": "latest",
-    "agents": "latest",
-    "@ai-sdk/openai": "latest",
     "shadcn-ui": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- use `@openai/agents` for chat handling
- convert chat history to agent messages and stream responses
- document OpenAI Agents SDK usage
- include `@openai/agents` in dependencies

## Testing
- `npm run build` *(fails: page.tsx doesn't have a root layout)*

------
https://chatgpt.com/codex/tasks/task_b_68549c00cad8832aa9cbba192b6e81f5