### PR TITLE
Improve error handling in /api/chat

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,6 @@
-import { Agent, run } from '@openai/agents';
+import { Agent, run, type AgentInputItem } from '@openai/agents';
 import { createDataStreamResponse, formatDataStreamPart } from 'ai';
+import { NextResponse } from 'next/server';
 
 export const runtime = 'edge';
 
@@ -10,31 +11,46 @@ const agent = new Agent({
 });
 
 export async function POST(req: Request) {
-  const { messages } = await req.json();
+  try {
+    const { messages } = await req.json();
 
-  const history = messages.map((m: { role: string; content: string }) => {
-    if (m.role === 'system') {
-      return { role: 'system', content: m.content } as const;
+    if (!Array.isArray(messages)) {
+      return NextResponse.json(
+        { error: 'Invalid request payload' },
+        { status: 400 }
+      );
     }
-    if (m.role === 'assistant') {
-      return {
-        role: 'assistant',
-        status: 'completed',
-        content: [{ type: 'output_text', text: m.content }]
-      } as const;
-    }
-    return {
-      role: 'user',
-      content: [{ type: 'input_text', text: m.content }]
-    } as const;
-  });
 
-  const result = await run(agent, history, { stream: true });
-  return createDataStreamResponse({
-    async execute(writer) {
-      for await (const chunk of result.toTextStream()) {
-        writer.write(formatDataStreamPart('text', chunk));
+    const history: AgentInputItem[] = messages.map((m: { role: string; content: string }) => {
+      if (m.role === 'system') {
+        return { role: 'system', content: m.content } as const;
       }
-    }
-  });
+      if (m.role === 'assistant') {
+        return {
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: m.content }]
+        } as const;
+      }
+      return {
+        role: 'user',
+        content: [{ type: 'input_text', text: m.content }]
+      } as const;
+    });
+
+    const result = await run(agent, history, { stream: true });
+    return createDataStreamResponse({
+      async execute(writer) {
+        for await (const chunk of result.toTextStream()) {
+          writer.write(formatDataStreamPart('text', chunk));
+        }
+      }
+    });
+  } catch (err) {
+    console.error('Chat error:', err);
+    return NextResponse.json(
+      { error: 'An unexpected error occurred.' },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- handle malformed requests and runtime errors in `POST /api/chat`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6854a8b9dd6c832a9e691fd05be6feff