### PR TITLE
Improve Chat UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import './globals.css';
 
 export const metadata = {
   title: 'AI App',

--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -2,9 +2,10 @@
 
 import { useChat } from 'ai/react';
 import { Button } from './ui/button';
-import { Input } from './ui/input';
+import { Textarea } from './ui/textarea';
 import { Card } from './ui/card';
 import { useEffect, useRef } from 'react';
+import { Message } from './Message';
 
 export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit } = useChat({
@@ -19,29 +20,23 @@ export default function Chat() {
 
   return (
     <Card className="flex flex-col gap-4 max-w-2xl mx-auto p-4">
-      <div className="flex flex-col gap-3 max-h-[70vh] overflow-auto">
-        {messages.map(m => (
-          <div
-            key={m.id}
-            className={`whitespace-pre-wrap p-3 rounded-md max-w-sm ${
-              m.role === 'user'
-                ? 'bg-blue-600 text-white self-end'
-                : 'bg-gray-100 dark:bg-gray-700'
-            }`}
-          >
-            {m.content}
-          </div>
+      <div className="flex flex-col gap-4 overflow-y-auto pr-2" style={{ maxHeight: '70vh' }}>
+        {messages.map((m) => (
+          <Message key={m.id} role={m.role as 'user' | 'assistant'}>{m.content}</Message>
         ))}
         <div ref={endRef} />
       </div>
       <form onSubmit={handleSubmit} className="flex gap-2">
-        <Input
+        <Textarea
           value={input}
           onChange={handleInputChange}
           placeholder="Ask me anything..."
-          className="flex-1"
+          className="flex-1 resize-none"
+          rows={2}
         />
-        <Button type="submit">Send</Button>
+        <Button type="submit" className="self-end">
+          Send
+        </Button>
       </form>
     </Card>
   );

--- a/components/Message.tsx
+++ b/components/Message.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+interface MessageProps {
+  role: 'user' | 'assistant';
+  children: ReactNode;
+}
+
+export function Message({ role, children }: MessageProps) {
+  const isUser = role === 'user';
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : ''}`}>
+      <div
+        className={`whitespace-pre-wrap rounded-lg px-4 py-2 text-sm max-w-prose ${
+          isUser ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700'
+        }`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,10 @@
+import { TextareaHTMLAttributes } from 'react';
+
+export function Textarea({ className = '', ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      className={`flex min-h-[80px] w-full rounded-md border px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+      {...props}
+    />
+  );
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   "devDependencies": {
     "typescript": "^5.0.0",
     "@types/react": "latest",
-    "@types/node": "latest"
+    "@types/node": "latest",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.10",
+    "@tailwindcss/postcss": "^4.1.10"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};


### PR DESCRIPTION
## Summary
- make message layout more chatgpt-like
- add new Message and Textarea shadcn-inspired components

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6854a8bf8300832a86946746b2e44ac2