### PR TITLE
Add eval docs and refine runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,29 @@ npx ts-node scripts/test-chat.ts
 ```
 
 This script sends a sample message and streams the reply to standard output.
+
+## Evaluations
+
+Evals provide a quick way to verify expected behaviour and encourage a
+test‑driven workflow. Each evaluation script lives under `scripts/evals` and
+uses the TypeScript Agents SDK to run the agent directly.
+
+- Keep evals focused on a single behaviour.
+- Assert against `result.finalOutput` from `run()` or employ the `llmj` helper
+  to let another model judge the response.
+- Enable tracing with `AGENTS_TRACE=1` to debug failures.
+
+Run all available evals with the helper script:
+
+```bash
+npm run evals
+```
+
+You can also run a single eval for quicker feedback:
+
+```bash
+npx ts-node --esm scripts/evals/respond-hi.ts
+```
+
+When tracing is enabled the script prints a trace ID that can be inspected in
+the Agents tracing UI for deeper debugging.

--- a/app/api/chat/agent.ts
+++ b/app/api/chat/agent.ts
@@ -1,0 +1,7 @@
+import { Agent } from '@openai/agents';
+
+export const agent = new Agent({
+  name: 'assistant',
+  instructions: 'You are a helpful AI assistant.',
+  model: 'gpt-4o'
+});

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,14 +1,9 @@
-import { Agent, run, type AgentInputItem } from '@openai/agents';
+import { run, type AgentInputItem } from '@openai/agents';
+import { agent } from './agent';
 import { createDataStreamResponse, formatDataStreamPart } from 'ai';
 import { NextResponse } from 'next/server';
 
 export const runtime = 'edge';
-
-const agent = new Agent({
-  name: 'assistant',
-  instructions: 'You are a helpful AI assistant.',
-  model: 'gpt-4o'
-});
 
 export async function POST(req: Request) {
   try {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "evals": "node scripts/run-evals.js"
   },
   "dependencies": {
     "@ai-sdk/openai": "latest",

--- a/scripts/evals/respond-hi.ts
+++ b/scripts/evals/respond-hi.ts
@@ -1,0 +1,25 @@
+import { run } from '@openai/agents';
+import { agent } from '../../app/api/chat/agent';
+import { llmj } from '../utils/llmj';
+
+async function main() {
+  const result = await run(agent, 'hi');
+  const output = result.finalOutput;
+
+  if (typeof output !== 'string') {
+    console.error('No text output from agent');
+    process.exit(1);
+  }
+
+  if (await llmj('greeting', output)) {
+    console.log('✅ Agent greeted:', output);
+  } else {
+    console.error('❌ Response failed greeting check:', output);
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('Eval error:', err);
+  process.exit(1);
+});

--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -1,0 +1,28 @@
+const { readdir } = require('fs/promises');
+const { join } = require('path');
+const { spawnSync } = require('child_process');
+
+async function main() {
+  const dir = join(__dirname, 'evals');
+  const files = await readdir(dir);
+  const evals = files.filter(f => f.endsWith('.ts'));
+  let failed = false;
+  for (const file of evals) {
+    console.log(`Running ${file}...`);
+    const result = spawnSync('npx', ['ts-node', '--esm', join(dir, file)], {
+      stdio: 'inherit'
+    });
+    if (result.status !== 0) {
+      console.error(`Eval ${file} failed`);
+      failed = true;
+    }
+  }
+  if (failed) {
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('Failed to run evals:', err);
+  process.exit(1);
+});

--- a/scripts/utils/llmj.ts
+++ b/scripts/utils/llmj.ts
@@ -1,0 +1,20 @@
+import { generateObject } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { z } from 'zod';
+
+/**
+ * Use a secondary LLM to judge whether `actual` meets the `expected` criterion.
+ * Returns `true` if the judge indicates success.
+ */
+export async function llmj(expected: string, actual: string): Promise<boolean> {
+  const { object } = await generateObject({
+    model: openai('gpt-3.5-turbo'),
+    schema: z.object({ pass: z.boolean() }),
+    prompt:
+      `Does the following response meet the expectation?\n` +
+      `Expectation: ${expected}\n` +
+      `Response: ${actual}\n` +
+      `Respond with JSON {"pass": true | false}.`
+  });
+  return object.pass;
+}


### PR DESCRIPTION
## Summary
- expand README guidance on eval-driven development
- simplify run-evals.js and exit with error when a script fails

## Testing
- `npm run build` *(fails: next not found)*
- `npx ts-node scripts/test-chat.ts` *(fails: prompts to install ts-node)*
- `npm run evals` *(fails: prompts to install ts-node)*


------
https://chatgpt.com/codex/tasks/task_b_6854b18333c8832aaa514119f009944d