### PR TITLE
Streamline runtime environment

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+proxy=http://proxy:8080
+https-proxy=http://proxy:8080
+loglevel=error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,18 @@ This repository is a minimal Next.js chat app that communicates with the OpenAI 
 - The app uses TypeScript with React components located under `app` and `components`.
 - The chat endpoint is implemented in `app/api/chat/route.ts` and uses `@openai/agents` to handle requests.
 - A script at `scripts/test-chat.ts` streams a sample request to `/api/chat` for quick verification.
+- Evaluation scripts live under `scripts/evals` and can all be executed with `npm run evals`.
+- Run `npm install` to ensure all dev dependencies like `tsx` are available.
+- NPM warnings are silenced via `.npmrc` which sets `loglevel=error`.
+- Browser-only APIs like `CustomEvent` are polyfilled in `lib/polyfills.ts`.
 
 ## Best Practices for Codex
 
 - **Keep commits focused.** Describe the change in the commit message and avoid mixing unrelated modifications.
 - **Run programmatic checks** before committing:
   - `npm run build` to ensure the Next.js project compiles.
-  - `npx ts-node scripts/test-chat.ts` to verify the chat endpoint.
+  - `npx tsx scripts/test-chat.ts` to verify the chat endpoint.
+  - `npm run evals` to execute TypeScript evals under `scripts/evals`.
 - If these commands fail in the Codex environment due to missing dependencies or network restrictions, include the standard disclaimer about environment limitations in the PR description.
 - Update documentation if you add or change any scripts or commands referenced in `README.md`.
 - Use modern TypeScript and React patterns. Prefer functional components and hooks.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,3 +1,4 @@
+import '../../../lib/polyfills';
 import { run, type AgentInputItem } from '@openai/agents';
 import { agent } from './agent';
 import { createDataStreamResponse, formatDataStreamPart } from 'ai';

--- a/lib/polyfills.ts
+++ b/lib/polyfills.ts
@@ -1,0 +1,14 @@
+// Polyfill the browser-only CustomEvent API when executed in Node.js
+if (typeof (globalThis as any).CustomEvent === 'undefined') {
+  interface CustomEventInit<T = unknown> extends EventInit {
+    detail?: T;
+  }
+  class CustomEventPolyfill<T = unknown> extends Event {
+    public readonly detail: T;
+    constructor(type: string, params: CustomEventInit<T> = {}) {
+      super(type, params);
+      this.detail = params.detail as T;
+    }
+  }
+  (globalThis as any).CustomEvent = CustomEventPolyfill;
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "NEXT_TELEMETRY_DISABLED=1 next dev",
     "build": "next build",
     "start": "next start",
     "evals": "node scripts/run-evals.js"
@@ -21,6 +21,7 @@
   "devDependencies": {
     "typescript": "^5.0.0",
     "@types/react": "latest",
-    "@types/node": "latest"
+    "@types/node": "latest",
+    "tsx": "latest"
   }
 }

--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -9,7 +9,7 @@ async function main() {
   let failed = false;
   for (const file of evals) {
     console.log(`Running ${file}...`);
-    const result = spawnSync('npx', ['ts-node', '--esm', join(dir, file)], {
+    const result = spawnSync('npx', ['tsx', join(dir, file)], {
       stdio: 'inherit'
     });
     if (result.status !== 0) {

--- a/scripts/test-chat.ts
+++ b/scripts/test-chat.ts
@@ -1,3 +1,4 @@
+import '../lib/polyfills';
 import { Readable } from 'node:stream';
 
 async function main() {


### PR DESCRIPTION
## Summary
- polyfill `CustomEvent` for Node.js runtime
- silence npm warnings with `.npmrc`
- document polyfills and warning suppression for future agents

## Testing
- `npm run build`
- `npx tsx scripts/test-chat.ts` *(fails: Request failed with status 500)*
- `npm run evals` *(fails: APIConnectionError)*

------
https://chatgpt.com/codex/tasks/task_b_6854c18e09d0832a83771708b9ce38b6