### PR TITLE
Add orders and billing agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AI App Scaffold
 
 This project provides a minimal Next.js setup using the OpenAI Agents SDK together with shadcn components. Chat requests sent to `/api/chat` are handled using the Agents SDK.
+The main assistant can delegate work to dedicated sub‑agents. An **orders** agent exposes a `get_orders` tool for returning recent orders, and a **billing** agent answers invoice questions.
 
 ## Getting Started
 
@@ -37,6 +38,8 @@ You can also run a single eval for quicker feedback:
 
 ```bash
 npx tsx scripts/evals/respond-hi.ts
+# or test the orders agent
+npx tsx scripts/evals/get-orders.ts
 ```
 
 When tracing is enabled the script prints a trace ID that can be inspected in

--- a/app/api/chat/agent.ts
+++ b/app/api/chat/agent.ts
@@ -1,7 +1,39 @@
-import { Agent } from '@openai/agents';
+import { Agent, tool } from '@openai/agents';
+import { z } from 'zod';
 
-export const agent = new Agent({
+// Tool for the orders agent
+const getOrdersTool = tool({
+  name: 'get_orders',
+  description: 'Retrieve recent orders',
+  // No parameters for now
+  parameters: z.object({}),
+  async execute() {
+    return [{ id: '1', item: 'Widget', price: 9.99 }];
+  }
+});
+
+// Orders agent providing order information
+export const ordersAgent = new Agent({
+  name: 'orders',
+  instructions: 'You manage user orders.',
+  handoffDescription: 'Handles order related queries',
+  tools: [getOrdersTool],
+  toolUseBehavior: 'stop_on_first_tool',
+  model: 'gpt-4o'
+});
+
+// Billing agent placeholder
+export const billingAgent = new Agent({
+  name: 'billing',
+  instructions: 'You answer billing questions.',
+  handoffDescription: 'Handles billing and invoices',
+  model: 'gpt-4o'
+});
+
+// Main assistant agent with access to other agents
+export const agent = Agent.create({
   name: 'assistant',
   instructions: 'You are a helpful AI assistant.',
+  handoffs: [ordersAgent, billingAgent],
   model: 'gpt-4o'
 });

--- a/scripts/evals/get-orders.ts
+++ b/scripts/evals/get-orders.ts
@@ -1,0 +1,17 @@
+import { run } from '@openai/agents';
+import { agent } from '../../app/api/chat/agent';
+
+async function main() {
+  const result = await run(agent, 'show my orders');
+  const output = result.finalOutput;
+  if (!output) {
+    console.error('No output from agent');
+    process.exit(1);
+  }
+  console.log('✅ Orders agent responded:', output);
+}
+
+main().catch(err => {
+  console.error('Eval error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- extend agent setup with an orders agent and billing agent
- expose a `get_orders` tool
- document new agents in README and add sample eval

## Testing
- `npm run build`
- `npm run evals` *(fails: ENETUNREACH during OpenAI API call)*

------
https://chatgpt.com/codex/tasks/task_b_6854d2d3df4c832aa050eed24f1021ff