### PR TITLE
Update llmj to o4-mini model

### DIFF
--- a/scripts/utils/llmj.ts
+++ b/scripts/utils/llmj.ts
@@ -8,7 +8,7 @@ import { z } from 'zod';
  */
 export async function llmj(expected: string, actual: string): Promise<boolean> {
   const { object } = await generateObject({
-    model: openai('gpt-3.5-turbo'),
+    model: openai('o4-mini'),
     schema: z.object({ pass: z.boolean() }),
     prompt:
       `Does the following response meet the expectation?\n` +


### PR DESCRIPTION
## Summary
- switch `llmj` helper to use the `o4-mini` model

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm run evals` *(fails: requires installing `tsx`)*

------
https://chatgpt.com/codex/tasks/task_b_6854d36da04c832a820b6178a73cb5dc