### PR TITLE
Clarify initial setup order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,10 @@ This repository is a minimal Next.js chat app that communicates with the OpenAI 
 ## Best Practices for Codex
 
 - **Keep commits focused.** Describe the change in the commit message and avoid mixing unrelated modifications.
-- **Run programmatic checks** before committing:
-  - `npm run build` to ensure the Next.js project compiles.
-  - `npm run evals` to test the agent directly without hitting the endpoint.
+- **Initial setup**: run `npm install` immediately after launching the environment so all packages are available before running any scripts.
+- **Run programmatic checks** in the following order after installation:
+  1. `npm run build` to ensure the Next.js project compiles.
+  2. `npm run evals` to test the agent directly without hitting the endpoint.
 - If these commands fail in the Codex environment due to missing dependencies or network restrictions, include the standard disclaimer about environment limitations in the PR description.
 - Update documentation if you add or change any scripts or commands referenced in `README.md`.
 - Use modern TypeScript and React patterns. Prefer functional components and hooks.


### PR DESCRIPTION
## Summary
- specify running `npm install` before any other scripts in AGENTS guidelines

## Testing
- `npm run build`
- `npm run evals` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_6854d94a2274832a9f3694dd84733ba8