### PR TITLE
Revert README change

### DIFF
--- a/scripts/evals/query-orders.ts
+++ b/scripts/evals/query-orders.ts
@@ -1,0 +1,17 @@
+import { run } from '@openai/agents';
+import { agent } from '../../app/api/chat/agent';
+
+async function main() {
+  const result = await run(agent, 'do i have any orders?');
+  const output = result.finalOutput;
+  if (typeof output !== 'string' || output.trim() === '') {
+    console.error('No text output from orders query');
+    process.exit(1);
+  }
+  console.log('✅ Orders query responded:', output);
+}
+
+main().catch(err => {
+  console.error('Eval error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `query-orders.ts` eval to verify order queries
- keep documentation streamlined by removing mention of the new eval

## Testing
- `npm run build`
- `npm run evals` *(fails: APIConnectionError ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_6854da68805c832aa580a0c853f4cab7