### PR TITLE
Convert JS scripts to TypeScript

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
-
-module.exports = nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "evals": "node scripts/run-evals.js"
+    "evals": "tsx scripts/run-evals.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "latest",

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -1,16 +1,16 @@
-const { readdir } = require('fs/promises');
-const { join } = require('path');
-const { spawnSync } = require('child_process');
+import { readdir } from 'fs/promises';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
 
 async function main() {
   const dir = join(__dirname, 'evals');
   const files = await readdir(dir);
-  const evals = files.filter(f => f.endsWith('.ts'));
+  const evals = files.filter((f) => f.endsWith('.ts'));
   let failed = false;
   for (const file of evals) {
     console.log(`Running ${file}...`);
     const result = spawnSync('npx', ['tsx', join(dir, file)], {
-      stdio: 'inherit'
+      stdio: 'inherit',
     });
     if (result.status !== 0) {
       console.error(`Eval ${file} failed`);
@@ -22,7 +22,7 @@ async function main() {
   }
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Failed to run evals:', err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- convert run-evals script to TypeScript
- use tsx to execute evals
- rewrite `next.config.js` as `next.config.ts`

## Testing
- `npm run build`
- `npm run evals` *(fails: APIConnectionError: Connection error)*

------
https://chatgpt.com/codex/tasks/task_b_6854e68a1968832a98336783b551c7c6